### PR TITLE
Add AssignStmtNode

### DIFF
--- a/compiler/Parser.java
+++ b/compiler/Parser.java
@@ -169,6 +169,19 @@ public class Parser {
     }
 
     ASTStmtNode getAssignStmt() throws Exception {
+        // assignStmt: IDENTIFIER ASSIGN expr SEMICOLON
+        Token nextToken = m_lexer.lookAhead();
+        if(nextToken.m_type == Type.IDENT) {
+            if(m_symbolTable.getSymbol(nextToken.m_value) != null) {
+                m_lexer.advance();
+                m_lexer.expect(Type.ASSIGN);
+                ASTExprNode expr = getQuestionMarkExpr();
+                m_lexer.expect(Type.SEMICOLON);
+                return new ASTAssignStmtNode(nextToken, expr, m_symbolTable);
+            } else {
+                throw new CompilerException("Identifier has not been declared " + nextToken.m_value, m_lexer.m_input.getLine(), m_lexer.m_input.currentLine(), "Identifier should have been declared before use");
+            }
+        }
         return null;
     }
 

--- a/compiler/ast/ASTAssignStmtNode.java
+++ b/compiler/ast/ASTAssignStmtNode.java
@@ -1,0 +1,37 @@
+package compiler.ast;
+
+import compiler.SymbolTableIntf;
+import compiler.Token;
+
+import java.io.OutputStreamWriter;
+
+public class ASTAssignStmtNode extends ASTStmtNode {
+    Token m_identifier;
+    ASTExprNode m_expr;
+    SymbolTableIntf m_symbolTable;
+
+    public ASTAssignStmtNode(Token identifier, ASTExprNode expr, SymbolTableIntf symbolTable) {
+        this.m_identifier = identifier;
+        this.m_expr = expr;
+        this.m_symbolTable = symbolTable;
+    }
+
+    @Override
+    public void print(OutputStreamWriter outStream, String indent) throws Exception {
+        outStream.write(indent);
+        outStream.write("AssignStmt \n");
+        outStream.write(indent + "  ");
+        outStream.write(m_identifier.m_value + "\n");
+        outStream.write(indent + "  ");
+        outStream.write("ASSIGN \n");
+        outStream.write(indent);
+        m_expr.print(outStream, indent + "  ");
+        outStream.write(indent + "  ");
+        outStream.write("SEMICOLON \n");
+    }
+
+    @Override
+    public void execute() {
+        // m_symbolTable.getSymbol(identifier.m_value).set(expr.eval());
+    }
+}


### PR DESCRIPTION
Execute nicht vollständig implementiert, da wir nicht genau wussten wie/wo wir den neuen Wert der Variable zuweisen können.
**Idee**: m_symbolTable.getSymbol(identifier.m_value).set(expr.eval());
**Problem**: Set-Methode gibt es aber nicht, sondern nur Create und Get.