### PR TITLE
Add execute to AssignStmtNode

### DIFF
--- a/compiler/ast/ASTAssignStmtNode.java
+++ b/compiler/ast/ASTAssignStmtNode.java
@@ -32,6 +32,6 @@ public class ASTAssignStmtNode extends ASTStmtNode {
 
     @Override
     public void execute() {
-        // m_symbolTable.getSymbol(identifier.m_value).set(expr.eval());
+         m_symbolTable.getSymbol(m_identifier.m_value).m_number = m_expr.eval();
     }
 }


### PR DESCRIPTION
Implementation der Execute-Methode. 
Jedoch gibt es **m_value** beim Symbol nicht, weshalb davon ausgegangen wurde, dass **m_number** das richtige Attribut ist.