### PR TITLE
Add codegen for LOOP stmt

### DIFF
--- a/compiler/ast/ASTBreakStmtNode.java
+++ b/compiler/ast/ASTBreakStmtNode.java
@@ -1,5 +1,7 @@
 package compiler.ast;
 
+import compiler.instr.InstrJmp;
+
 import java.io.OutputStreamWriter;
 
 public class ASTBreakStmtNode extends ASTStmtNode {
@@ -21,6 +23,8 @@ public class ASTBreakStmtNode extends ASTStmtNode {
 
     @Override
     public void codegen(compiler.CompileEnvIntf compileEnv) {
-
+        compiler.InstrBlock exitBlock = compileEnv.popLoopStack();
+        compiler.InstrIntf jmpExit = new InstrJmp(exitBlock);
+        compileEnv.addInstr(jmpExit);
     }
 }

--- a/compiler/ast/ASTLoopStmtNode.java
+++ b/compiler/ast/ASTLoopStmtNode.java
@@ -1,5 +1,7 @@
 package compiler.ast;
 
+import compiler.instr.InstrJmp;
+
 import java.io.OutputStreamWriter;
 
 public class ASTLoopStmtNode extends ASTStmtNode {
@@ -30,7 +32,17 @@ public class ASTLoopStmtNode extends ASTStmtNode {
 
     @Override
     public void codegen(compiler.CompileEnvIntf compileEnv) {
+        compiler.InstrBlock loopBlock = compileEnv.createBlock("LOOP");
+        compiler.InstrBlock exitBlock = compileEnv.createBlock("LOOP_EXIT");
 
+        compiler.InstrIntf jmpLoop = new InstrJmp(loopBlock);
+
+        compileEnv.setCurrentBlock(loopBlock);
+        compileEnv.pushLoopStack(exitBlock);
+        m_stmtNode.codegen(compileEnv);
+        compileEnv.addInstr(jmpLoop);
+
+        compileEnv.setCurrentBlock(exitBlock);
     }
 
     static class BreakLoopException extends RuntimeException {


### PR DESCRIPTION
We are not sure if we used the loop stack correctly. But this was the only way to access the exit block inside the BREAK stmt.