### PR TITLE
Fix doWhile and add semicolons

### DIFF
--- a/compiler/Parser.java
+++ b/compiler/Parser.java
@@ -350,23 +350,25 @@ public class Parser {
     }
 
     ASTStmtNode getWhileStmt() throws Exception {
-        // WHILE LPAREN expr RPAREN blockStmt
+        // WHILE LPAREN expr RPAREN blockStmt SEMICOLON
         m_lexer.expect(Type.WHILE);
         m_lexer.expect(Type.LPAREN);
         ASTExprNode expr = getQuestionMarkExpr();
         m_lexer.expect(Type.RPAREN);
         ASTStmtNode blockStmt = getBlockStmt();
+        m_lexer.expect(Type.SEMICOLON);
         return new ASTWhileStmtNode(blockStmt, expr);
     }
 
     ASTStmtNode getDoWhileStmt() throws Exception {
-        // DO blockstmt WHILE LPAREN expr RPAREN
+        // DO blockstmt WHILE LPAREN expr RPAREN SEMICOLON
         m_lexer.expect(Type.DO);
         ASTStmtNode blockStmt = getBlockStmt();
         m_lexer.expect(Type.WHILE);
         m_lexer.expect(Type.LPAREN);
         ASTExprNode expr = getQuestionMarkExpr();
         m_lexer.expect(Type.RPAREN);
+        m_lexer.expect(Type.SEMICOLON);
         return new ASTDoWhileStmtNode(blockStmt, expr);
     }
 }

--- a/compiler/ast/ASTDoWhileStmtNode.java
+++ b/compiler/ast/ASTDoWhileStmtNode.java
@@ -41,6 +41,6 @@ public class ASTDoWhileStmtNode extends ASTStmtNode {
         compiler.InstrIntf condJmp = new compiler.instr.InstrCondJump(condition, doWhileBlock, doWhileExit);
         env.addInstr(condJmp);
 
-        env.setCurrentBlock(doWhileBlock);
+        env.setCurrentBlock(doWhileExit);
     }
 }


### PR DESCRIPTION
Wir haben jetzt dem While und Do-While ein Semicolon am Ende in der Grammatik hinzugefügt, damit es zu den Testcases passt. 